### PR TITLE
Option for precalculating dpo probs

### DIFF
--- a/EasyLM/data.py
+++ b/EasyLM/data.py
@@ -88,7 +88,7 @@ class TextProcessor(object):
     def get_default_config(updates=None):
         config = ConfigDict()
         config.fields_from_example = ''
-        config.fields = ''
+        config.fields = '[prompt],completion'
         config.subfield_separator = ' '
         config.add_bos_token = True
         config.add_eos_token = True

--- a/EasyLM/data.py
+++ b/EasyLM/data.py
@@ -12,6 +12,8 @@ import torch
 from torch.utils.data import DataLoader
 from transformers.data.data_collator import numpy_default_data_collator
 from tqdm import tqdm
+import jax
+import jax.numpy as jnp
 
 class DatasetFactory(object):
     """ Datset builder class. """
@@ -478,9 +480,10 @@ class JsonTorchDataset(object):
             raise ValueError('Must specify either path or hf_name')
         self.dataset = dataset.map(
             self._process_sample,
+            with_indices=True,
             batched=False,
             num_proc=self.config.num_workers,
-            remove_columns=[x for x in dataset.column_names if x not in ['input_tokens', 'target_tokens', 'loss_masks', 'attention_mask']],)
+            remove_columns=[x for x in dataset.column_names if x not in ['input_tokens', 'target_tokens', 'loss_masks', 'attention_mask', 'indices']],)
 
     def _json_iterator(self):
         with mlxu.open_file(self.config.path, 'r') as fin:
@@ -497,7 +500,7 @@ class JsonTorchDataset(object):
     def __getitem__(self, idx):
         return self.dataset[idx]
     
-    def _process_sample(self, sample):
+    def _process_sample(self, sample, idx):
         tokens = self.tokenizer.encode(sample['prompt'] + sample['completion'])
         tokens = tokens[:self.config.seq_length]
         tokens = [self.tokenizer.bos_token_id] + tokens + [self.tokenizer.eos_token_id]
@@ -544,7 +547,7 @@ class JsonTorchDataset(object):
 
 class TuluJsonTorchDataset(JsonTorchDataset):
 
-    def _process_sample(self, sample):
+    def _process_sample(self, sample, idx):
         # run tulu processor
         tokens, labels, attention_mask = self.encode_with_messages_format(sample['messages'], self.tokenizer, self.config.seq_length)
         loss_masks = [1.0 if x != -100 else 0.0 for x in labels]
@@ -626,7 +629,7 @@ class TuluJsonTorchDataset(JsonTorchDataset):
 # that is, chosen and rejected are both setup right.
 class PreferenceDataset(TuluJsonTorchDataset):
 
-    def _process_sample(self, sample):
+    def _process_sample(self, sample, idx):
         chosen_input_ids, chosen_labels, chosen_attn_mask = self.encode_with_messages_format(sample['chosen'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
         rejected_input_ids, rejected_labels, rejected_attn_mask = self.encode_with_messages_format(sample['rejected'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
         # convert to lists
@@ -653,8 +656,22 @@ class PreferenceDataset(TuluJsonTorchDataset):
             "rejected_input_ids": np.array(rejected_input_ids, dtype=np.int32),
             "rejected_loss_mask": np.array(rejected_loss_mask, dtype=np.float32),
             "rejected_attn_mask": np.array(rejected_attn_mask, dtype=np.int32),
+            "indices": np.array(idx, dtype=np.int32),
         }
-
+    
+# util method for padding out a batch to match a batch size. This lets us use small batches
+# while still respecting the TPU sharding
+def pad_out_to_full_batch(desired_batch_size, batch):
+    for key in batch:
+        padding_config = [(0, desired_batch_size - batch[key].shape[0], 0),]
+        if len(batch[key].shape) > 1:
+            padding_config += [(0, 0, 0) for _ in range(len(batch[key].shape) - 1)]
+        batch[key] = jax.lax.pad(
+            batch[key],
+            padding_value=jnp.array(0, dtype=batch[key].dtype),
+            padding_config=padding_config,
+        )
+    return batch
 
 if __name__ == "__main__":
     from EasyLM.models.llama.llama_model import LLaMATokenizer

--- a/EasyLM/models/llama/llama_train_dpo.py
+++ b/EasyLM/models/llama/llama_train_dpo.py
@@ -409,8 +409,8 @@ def main(argv):
                 if FLAGS.precalculate_reference_logps:
                     reference_train_state = None
                     # gather based on indices in batch
-                    reference_chosen_logps = all_reference_chosen_logps[batch['indices']]
-                    reference_rejected_logps = all_reference_rejected_logps[batch['indices']]
+                    reference_chosen_logps = all_reference_chosen_logps[batch['indices']].squeeze(1)
+                    reference_rejected_logps = all_reference_rejected_logps[batch['indices']].squeeze(1)
                     reference_logps = (reference_chosen_logps, reference_rejected_logps)
                 else:
                     reference_logps = None

--- a/EasyLM/models/llama/llama_train_dpo.py
+++ b/EasyLM/models/llama/llama_train_dpo.py
@@ -57,6 +57,7 @@ FLAGS, FLAGS_DEF = mlxu.define_flags_with_default(
     dpo_beta=0.1,
     dpo_label_smoothing=0.0,  # label smoothing for constrained DPO
     use_ipo=False,  # use IPO instead of DPO
+    precalculate_reference_logps=False,  # precalculate reference logps, speeds up training and saves memory.
 )
 
 
@@ -118,10 +119,17 @@ def concatenated_forward(model, params, rng, batch, train=True):
     return chosen_logps, rejected_logps
 
 
-def dpo_forward(model, policy_params, reference_params, rng, batch, beta, label_smoothing=0.0, use_ipo=False, train=True):
-    policy_chosen_logps, policy_rejected_logps = concatenated_forward(model, policy_params, rng, batch)
+def dpo_forward(
+        model, params, rng, batch, beta, label_smoothing=0.0,
+        use_ipo=False, reference_logps=None, reference_params=None
+    ):
+    assert reference_logps is not None or reference_params is not None, "Must provide either reference logps or reference params!"
+    if reference_logps is not None:
+        reference_chosen_logps, reference_rejected_logps = reference_logps
+    else:
+        reference_chosen_logps, reference_rejected_logps = concatenated_forward(model, reference_params, rng, batch)
     # jax doesnt have a 'no grad' manager, but if we stop gradients through the logps, this should work.
-    reference_chosen_logps, reference_rejected_logps = concatenated_forward(model, reference_params, rng, batch)
+    policy_chosen_logps, policy_rejected_logps = concatenated_forward(model, params, rng, batch)
     reference_chosen_logps = jax.lax.stop_gradient(reference_chosen_logps)
     reference_rejected_logps = jax.lax.stop_gradient(reference_rejected_logps)
 
@@ -227,18 +235,19 @@ def main(argv):
         )
         return TrainState.create(params=params, tx=optimizer, apply_fn=None)
 
-    def train_step(train_state, reference_train_state, rng, batch):
+    def train_step(train_state, rng, batch, reference_logps=None, reference_train_state=None):
         rng_generator = JaxRNG(rng)
         batch = with_sharding_constraint(batch, PS(('dp', 'fsdp')))
         loss_and_metrics = lambda params: dpo_forward(
             model,
             params,
-            reference_train_state.params,
             rng_generator(llama_config.rng_keys()),
             batch,
             beta=FLAGS.dpo_beta,
             label_smoothing=FLAGS.dpo_label_smoothing,
             use_ipo=FLAGS.use_ipo,
+            reference_logps=reference_logps,
+            reference_params=reference_train_state.params if reference_train_state is not None else None,
         )
         grad_fn = jax.value_and_grad(loss_and_metrics, has_aux=True)
         (_, metrics), grads = grad_fn(train_state.params)
@@ -251,12 +260,13 @@ def main(argv):
         })
         # we dont return the ref train state because we dont want to update it
         return train_state, rng_generator(), metrics
-
+    
     print("Initializing training state and pjitting...")
     train_state_shapes = jax.eval_shape(init_fn, next_rng())
     train_state_partition = match_partition_rules(
         LLaMAConfig.get_partition_rules(), train_state_shapes
     )
+    params_partition = train_state_partition.params
 
     shard_fns, gather_fns = make_shard_and_gather_fns(
         train_state_partition, train_state_shapes
@@ -279,11 +289,22 @@ def main(argv):
         donate_argnums=(0, ),
     )
 
+    if not FLAGS.precalculate_reference_logps:
+        in_shardings = (train_state_partition, PS(), PS(), PS(), train_state_partition)
+    else:
+        in_shardings = (train_state_partition, PS(), PS(), PS(), PS())
     sharded_train_step = pjit(
         train_step,
-        in_shardings=(train_state_partition, train_state_partition, PS(), PS()),
+        in_shardings=in_shardings,
         out_shardings=(train_state_partition, PS(), PS()),
         donate_argnums=(0, 2),  # train state and rng
+    )
+
+    no_model_concate_forward = lambda train_state, rng, batch: concatenated_forward(model, train_state, rng, batch, train=False)
+    sharded_concatenated_forward = pjit(
+        no_model_concate_forward,
+        in_shardings=(params_partition, PS(), PS()),
+        out_shardings=(PS(), PS()),
     )
 
     def save_checkpoint(train_state, milestone=False):
@@ -319,24 +340,42 @@ def main(argv):
             train_state = sharded_create_trainstate_from_params(restored_params)
             del restored_params
         
-        # currently I just create a new train state for the reference params,
-        # but it would be nice if I could directly shard the params and use them...
-        if FLAGS.load_checkpoint != '':
-            print("Loading reference params... (may take time to download)")
-            _, reference_params = checkpointer.load_trainstate_checkpoint(
-                FLAGS.load_checkpoint, train_state_shapes, shard_fns
-            )
-            print("Reference params loaded.")
+        if not FLAGS.precalculate_reference_logps:
+            # currently I just create a new train state for the reference params,
+            # but it would be nice if I could directly shard the params and use them...
+            if FLAGS.load_checkpoint != '':
+                print("Loading reference params... (may take time to download)")
+                _, reference_params = checkpointer.load_trainstate_checkpoint(
+                    FLAGS.load_checkpoint, train_state_shapes, shard_fns
+                )
+                print("Reference params loaded.")
+            else:
+                print("Warning, your dpo reference params are not loaded from a checkpoint!")
+                
+            if reference_train_state is None and reference_params is None:
+                # Initialize from scratch
+                reference_train_state = sharded_init_fn(next_rng())
+            elif reference_train_state is None and reference_params is not None:
+                # Restore from params but initialize train_state
+                reference_train_state = sharded_create_trainstate_from_params(reference_params)
+                del reference_params
         else:
-            print("Warning, your dpo reference params are not loaded from a checkpoint!")
-            
-        if reference_train_state is None and reference_params is None:
-            # Initialize from scratch
-            reference_train_state = sharded_init_fn(next_rng())
-        elif reference_train_state is None and reference_params is not None:
-            # Restore from params but initialize train_state
-            reference_train_state = sharded_create_trainstate_from_params(reference_params)
-            del reference_params
+            # run an epoch to precalculate policy logps
+            print("Precalculating policy logps...")
+            all_reference_chosen_logps = []
+            all_reference_rejected_logps = []
+            for batch in tqdm(dataset):
+                rng = next_rng()
+                rng_generator = JaxRNG(rng)
+                # rng shouldnt matter here since i think?
+                reference_chosen_logps, reference_rejected_logps = sharded_concatenated_forward(
+                    train_state.params, rng_generator(llama_config.rng_keys()), batch
+                )
+                all_reference_chosen_logps.append(jax.device_get(reference_chosen_logps))
+                all_reference_rejected_logps.append(jax.device_get(reference_rejected_logps))
+                del reference_chosen_logps, reference_rejected_logps
+            all_reference_chosen_logps = jnp.concatenate(all_reference_chosen_logps, axis=0)
+            all_reference_rejected_logps = jnp.concatenate(all_reference_rejected_logps, axis=0)                
 
         start_step = int(jax.device_get(train_state.step))
 
@@ -353,8 +392,17 @@ def main(argv):
         for epoch in epoch_counter:
             for step, batch in zip(step_counter, dataset):
                 start_time = time.time()
+                if FLAGS.precalculate_reference_logps:
+                    reference_train_state = None
+                    reference_chosen_logps = all_reference_chosen_logps[step * real_batch_size:(step + 1) * real_batch_size]
+                    reference_rejected_logps = all_reference_rejected_logps[step * real_batch_size:(step + 1) * real_batch_size]
+                    reference_logps = (reference_chosen_logps, reference_rejected_logps)
+                else:
+                    reference_logps = None
+
                 train_state, sharded_rng, metrics = sharded_train_step(
-                    train_state, reference_train_state, sharded_rng, batch
+                    train_state, sharded_rng, batch, reference_logps, reference_train_state
+
                 )
                 step_time = time.time() - start_time
                 overall_step += 1

--- a/docs/ai2.md
+++ b/docs/ai2.md
@@ -39,6 +39,8 @@ gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu 
 
 Anyway, now we are set up! If you need to delete a TPU, you can use the `gcloud alpha compute tpus tpu-vm delete` command.
 
+**NOTE: It is important to note that for all the commands below, you should be running them on all workers with `gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu --worker=all --command=` if you are using a TPU pod (anything over 8 cores)**
+
 ## Running EasyLM
 
 I'll omit the TPU ssh command bits here, but remember to use them for a TPU pod!

--- a/docs/ai2.md
+++ b/docs/ai2.md
@@ -39,7 +39,16 @@ gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu 
 
 Anyway, now we are set up! If you need to delete a TPU, you can use the `gcloud alpha compute tpus tpu-vm delete` command.
 
-**NOTE: It is important to note that for all the commands below, you should be running them on all workers with `gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu --worker=all --command=` if you are using a TPU pod (anything over 8 cores)**
+**NOTE: It is important to note that for all the commands below, you should be running them on all workers with `gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu --worker=all --command=` if you are using a TPU pod (anything over 8 cores). Yes, this means running the git clone command, setup script, and train command on multiple machines.**
+
+### Using Someone Else's TPU
+
+Sometimes it's useful to jump on someone else's TPU instead of yours (for example, if they are not using it). Only one person can use a TPU at a time, so please coordinate with the person as to who is using it. Sometimes the previous user may have left lockfiles that cause permission errors. You can fix these by removing the lockfiles:
+```bash
+sudo rm -rf /tmp/libtpu_lockfile /tmp/tpu_logs
+```
+
+And again, you should be running this via `gcloud alpha compute tpus tpu-vm ssh <name> --zone=us-east1-d --project=ai2-tpu --worker=all --command=` if you are using a TPU pod.
 
 ## Running EasyLM
 

--- a/examples/dpo_test.sh
+++ b/examples/dpo_test.sh
@@ -18,11 +18,13 @@ python -m EasyLM.models.llama.llama_train_dpo \
     --optimizer.accumulate_gradient_steps=8 \
     --train_dataset.type='preference_json_torch' \
     --train_dataset.text_processor.fields='[prompt],completion' \
-    --train_dataset.json_torch_dataset.path='debug_pref.json' \
+    --train_dataset.json_torch_dataset.hf_name='allenai/ultrafeedback_binarized_cleaned' \
+    --train_dataset.json_torch_dataset.hf_split='test_prefs' \
     --train_dataset.json_torch_dataset.seq_length=128 \
     --train_dataset.json_torch_dataset.batch_size=2 \
     --train_dataset.json_torch_dataset.num_workers=32 \
     --checkpointer.save_optimizer_state=False \
+    --precalculate_reference_logps=True \
     --logger.online=False \
     --logger.output_dir=tmp \
     --use_ipo=True

--- a/scripts/convert_and_submit_tuned.sh
+++ b/scripts/convert_and_submit_tuned.sh
@@ -18,4 +18,7 @@ BEAKER_ID=$(awk '/Uploading/ {print $4}' tmp.log)
 
 python scripts/submit_open_instruct_eval.py --workspace ${WORKSPACE} --model_name ${MODEL_NAME} --location ${BEAKER_ID} --cluster "ai2/allennlp-cirrascale" --num_gpus 1 --is_tuned
 
-echo  ${MODEL_NAME} uploaded to beaker with id ${BEAKER_ID} and submitted to open instruct eval. Check your beaker experiments for the results!"
+echo  "${MODEL_NAME} uploaded to beaker with id ${BEAKER_ID} and submitted to open instruct eval. Check your beaker experiments for the results!"
+
+# cleanup
+rm -rf tmp


### PR DESCRIPTION
While not commonly done in existing implementations, to be more efficient with DPO we can simply run our base model on our dataset once first, and then save its logps and re-use them when calculating the DPO loss.

This saves lots of time during training since we don't repeat the forward pass every epoch. It also saves memory since we only have to have one model loaded at a time.

Turn this on by setting `precalculate_reference_logps=True`. By default its off :)