### PR TITLE
Preference data

### DIFF
--- a/EasyLM/data.py
+++ b/EasyLM/data.py
@@ -648,7 +648,7 @@ class TuluJsonTorchDataset(JsonTorchDataset):
                     messages_so_far,
                     return_tensors='pt',
                     max_length=max_seq_length,
-                    truncation=self.config.truncate_messages
+                    truncation=True
                 ).input_ids.shape[1]
                 # we have to add bos offset
                 labels[:, message_start_idx+1:message_end_idx+1] = -100
@@ -725,7 +725,6 @@ if __name__ == "__main__":
             {
                 'path': 'debug.jsonl',
                 "seq_length": 1024,
-                "truncate_messages": False,
                 "num_workers": 1,
             }), tokenizer, text_processor)
     loader = DataLoader(

--- a/EasyLM/data.py
+++ b/EasyLM/data.py
@@ -4,16 +4,20 @@ import json
 import base64
 from multiprocessing import Pool
 
+
 import mlxu
 from ml_collections import ConfigDict
 import numpy as np
 from datasets import load_dataset, Dataset
 import torch
 from torch.utils.data import DataLoader
+from transformers.utils import logging
 from transformers.data.data_collator import numpy_default_data_collator
 from tqdm import tqdm
 import jax
 import jax.numpy as jnp
+
+logger = logging.get_logger(__name__)
 
 class DatasetFactory(object):
     """ Datset builder class. """
@@ -303,7 +307,7 @@ class JsonDataset(object):
         try:
             data = json.loads(line)
         except json.decoder.JSONDecodeError:
-            print(f'Error parsing json line:\n{line}')
+            logger.error(f'Error parsing json line:\n{line}')
             return None
         return data
 
@@ -426,7 +430,7 @@ class JsonDataset(object):
                 try:
                     data = json.loads(line)
                 except json.decoder.JSONDecodeError:
-                    print(f'Error parsing json line:\n{line}')
+                    logger.error(f'Error parsing json line:\n{line}')
                     continue
                 yield data
 
@@ -461,7 +465,7 @@ class JsonTorchDataset(object):
         config.seq_length = 1024
         config.batch_size = 8
         config.num_workers = 8
-        config.filter_truncated_examples = False
+        config.remove_truncated_samples = False
 
         if updates is not None:
             config.update(ConfigDict(updates).copy_and_resolve_references())
@@ -484,9 +488,21 @@ class JsonTorchDataset(object):
             with_indices=True,
             batched=False,
             num_proc=self.config.num_workers,
-            remove_columns=[x for x in dataset.column_names if x not in ['input_tokens', 'target_tokens', 'loss_masks', 'attention_mask', 'indices']],)
-        if self.config.filter_truncated_examples:
-            self.dataset = self.dataset.filter(lambda x: x['truncated'])
+            remove_columns=[x for x in dataset.column_names if x not in ['input_tokens', 'target_tokens', 'loss_masks', 'attention_mask', 'indices', 'truncated']],)
+        # filter out examples with no loss token
+        # these are useless anyway...
+        samples_before = len(self.dataset)
+        if 'loss_masks' in self.dataset.column_names:
+            self.dataset = self.dataset.filter(lambda x: sum(x['loss_masks'][1:]) > 0)
+        if 'chosen_loss_mask' in self.dataset.column_names:
+            self.dataset = self.dataset.filter(lambda x: sum(x['chosen_loss_mask'][1:]) > 0)
+        if 'rejected_loss_mask' in self.dataset.column_names:
+            self.dataset = self.dataset.filter(lambda x: sum(x['rejected_loss_mask'][1:]) > 0)
+        if self.config.remove_truncated_samples:
+            self.dataset = self.dataset.filter(lambda x: not x['truncated'])
+        self.dataset = self.dataset.remove_columns(['truncated'])
+        logger.info('Filtered out %d truncated examples.', samples_before - len(self.dataset))
+
 
     def _json_iterator(self):
         with mlxu.open_file(self.config.path, 'r') as fin:
@@ -496,7 +512,7 @@ class JsonTorchDataset(object):
                 try:
                     data = json.loads(line)
                 except json.decoder.JSONDecodeError:
-                    print(f'Error parsing json line:\n{line}')
+                    logger.error(f'Error parsing json line:\n{line}')
                     continue
                 yield data
 
@@ -505,6 +521,7 @@ class JsonTorchDataset(object):
     
     def _process_sample(self, sample, idx):
         tokens = self.tokenizer.encode(sample['prompt'] + sample['completion'])
+        truncated = False
         if len(tokens) > self.config.seq_length:
             tokens = tokens[:self.config.seq_length]
             truncated = True
@@ -555,7 +572,7 @@ class TuluJsonTorchDataset(JsonTorchDataset):
 
     def _process_sample(self, sample, idx):
         # run tulu processor
-        tokens, labels, attention_mask = self.encode_with_messages_format(sample['messages'], self.tokenizer, self.config.seq_length)
+        tokens, labels, attention_mask, truncated = self.encode_with_messages_format(sample['messages'], self.tokenizer, self.config.seq_length)
         loss_masks = [1.0 if x != -100 else 0.0 for x in labels]
         # before padding, account for shifting
         input_tokens = tokens[:-1].tolist()
@@ -572,6 +589,7 @@ class TuluJsonTorchDataset(JsonTorchDataset):
             "target_tokens": np.array(target_tokens, dtype=np.int32),
             "loss_masks": np.array(loss_masks, dtype=np.float32),
             "attention_mask": np.array(attention_mask, dtype=np.int32),
+            "truncated": truncated,
         }
 
     def encode_with_messages_format(self, messages, tokenizer, max_seq_length, only_train_last_message=False):
@@ -595,7 +613,19 @@ class TuluJsonTorchDataset(JsonTorchDataset):
             
         example_text = _concat_messages(messages).strip()
         example_text = tokenizer.bos_token + example_text
-        tokenized_example = tokenizer(example_text, return_tensors='pt', max_length=max_seq_length, truncation=True)
+        tokenized_example = tokenizer(
+            example_text,
+            return_tensors='pt',
+            max_length=max_seq_length,
+            truncation=True
+        )
+        untruncated_input_ids = tokenizer(
+            example_text,
+            return_tensors='pt',
+            max_length=max_seq_length,
+            truncation=False
+        )
+        truncated = tokenized_example.input_ids.shape[1] != untruncated_input_ids.input_ids.shape[1]
         input_ids = tokenized_example.input_ids
         labels = input_ids.clone()
 
@@ -616,9 +646,9 @@ class TuluJsonTorchDataset(JsonTorchDataset):
                     messages_so_far = _concat_messages(messages[:message_idx+1])
                 message_end_idx = tokenizer(
                     messages_so_far,
-                    return_tensors='pt', 
-                    max_length=max_seq_length, 
-                    truncation=True
+                    return_tensors='pt',
+                    max_length=max_seq_length,
+                    truncation=self.config.truncate_messages
                 ).input_ids.shape[1]
                 # we have to add bos offset
                 labels[:, message_start_idx+1:message_end_idx+1] = -100
@@ -627,7 +657,7 @@ class TuluJsonTorchDataset(JsonTorchDataset):
                     break
 
         attention_mask = torch.ones_like(input_ids)
-        return input_ids.flatten(), labels.flatten(), attention_mask.flatten()
+        return input_ids.flatten(), labels.flatten(), attention_mask.flatten(), truncated
     
 
 # for processing preference-style datasets
@@ -636,8 +666,8 @@ class TuluJsonTorchDataset(JsonTorchDataset):
 class PreferenceDataset(TuluJsonTorchDataset):
 
     def _process_sample(self, sample, idx):
-        chosen_input_ids, chosen_labels, chosen_attn_mask = self.encode_with_messages_format(sample['chosen'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
-        rejected_input_ids, rejected_labels, rejected_attn_mask = self.encode_with_messages_format(sample['rejected'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
+        chosen_input_ids, chosen_labels, chosen_attn_mask, chosen_truncated = self.encode_with_messages_format(sample['chosen'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
+        rejected_input_ids, rejected_labels, rejected_attn_mask, rejected_truncated = self.encode_with_messages_format(sample['rejected'], self.tokenizer, self.config.seq_length, only_train_last_message=True)
         # convert to lists
         chosen_input_ids = chosen_input_ids.tolist()
         chosen_labels = chosen_labels.tolist()
@@ -663,6 +693,7 @@ class PreferenceDataset(TuluJsonTorchDataset):
             "rejected_loss_mask": np.array(rejected_loss_mask, dtype=np.float32),
             "rejected_attn_mask": np.array(rejected_attn_mask, dtype=np.int32),
             "indices": np.array(idx, dtype=np.int32),
+            "truncated": chosen_truncated or rejected_truncated,
         }
     
 # util method for padding out a batch to match a batch size. This lets us use small batches
@@ -689,7 +720,14 @@ if __name__ == "__main__":
         truncation_side='right',
     )
     text_processor = TextProcessor({'fields': '[prompt],completion'}, tokenizer)
-    dataset = TuluJsonTorchDataset(TuluJsonTorchDataset.get_default_config({'hf_name': 'allenai/tulu-v2-sft-mixture', 'hf_split': 'train'}), tokenizer, text_processor)
+    dataset = PreferenceDataset(
+        PreferenceDataset.get_default_config(
+            {
+                'path': 'debug.jsonl',
+                "seq_length": 1024,
+                "truncate_messages": False,
+                "num_workers": 1,
+            }), tokenizer, text_processor)
     loader = DataLoader(
         dataset,
         batch_size=8,

--- a/EasyLM/models/llama/llama_model.py
+++ b/EasyLM/models/llama/llama_model.py
@@ -3,7 +3,6 @@ from shutil import copyfile
 from typing import Any, Dict, List, Optional, Tuple, Union
 import json
 import tempfile
-from functools import partial
 
 import numpy as np
 import jax
@@ -16,18 +15,16 @@ from flax.linen import combine_masks, make_causal_mask
 from flax.linen.attention import dot_product_attention_weights
 from flax.traverse_util import flatten_dict, unflatten_dict
 from flax.linen import partitioning as nn_partitioning
-import einops
 
 import sentencepiece as spm
 from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import logging
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.modeling_flax_outputs import FlaxBaseModelOutput, FlaxCausalLMOutput
-from transformers.modeling_flax_utils import ACT2FN, FlaxPreTrainedModel, append_call_sample_docstring
+from transformers.modeling_flax_utils import FlaxPreTrainedModel
 from transformers.utils import add_start_docstrings, add_start_docstrings_to_model_forward, logging
 
 from ml_collections import ConfigDict
-from ml_collections.config_dict import config_dict
 from mlxu import function_args_to_config, load_pickle, open_file
 
 from EasyLM.bpt import blockwise_ffn, blockwise_attn

--- a/EasyLM/models/llama/llama_model.py
+++ b/EasyLM/models/llama/llama_model.py
@@ -179,7 +179,7 @@ LLAMA_STANDARD_CONFIGS = {
         'num_hidden_layers': 80,
         'num_attention_heads': 64,
         'num_key_value_heads': 8,
-        'max_sequence_length': 8192,
+        'max_sequence_length': 16384,
         'initializer_range': 0.02,
         'rms_norm_eps': 1e-5,
         'use_cache': True,

--- a/conversion_scripts/convert_preference_data.py
+++ b/conversion_scripts/convert_preference_data.py
@@ -54,7 +54,7 @@ if args.input_dataset == 'nvidia/HelpSteer':
         })
 elif args.input_dataset == 'berkeley-nest/Nectar':
     for sample in dataset:
-        prompt = sample['prompt']
+        prompt = sample['prompt'].replace("Human: ", "").replace("Assistant: ", "").strip()
         answers = sorted(sample['answers'], key=lambda x: x['rank'])
         chosen = answers[0]['answer']
         rejected = random_gen.choice(answers[1:])['answer']
@@ -104,7 +104,7 @@ elif args.input_dataset == 'stanfordnlp/SHP' or args.input_dataset == 'stanfordn
             chosen = {'content': el['human_ref_B'], 'role': 'assistant'}
             rejected = {'content': el['human_ref_A'], 'role': 'assistant'}
         data = {}
-        data = {'prompt': el['history'], 'prompt_id': el['post_id'], 'chosen': [prompt, chosen], 'rejected': [prompt, rejected]}
+        data = {'chosen': [prompt, chosen], 'rejected': [prompt, rejected]}
         data['source'] = 'shp'
         new_data.append(data)
 elif args.input_dataset == 'Intel/orca_dpo_pairs':
@@ -165,7 +165,7 @@ elif args.input_dataset == "lvwerra/stack-exchange-paired":
         chosen = {'content': el['response_j'], 'role': 'assistant'}
         rejected = {'content': el['response_k'], 'role': 'assistant'}
         data = {}
-        data = {'prompt': el['question'], 'prompt_id': el['qid'], 'chosen': [prompt, chosen], 'rejected': [prompt, rejected]}
+        data = {'chosen': [prompt, chosen], 'rejected': [prompt, rejected]}
         data['source'] = 'stack-exchange-paired'
         new_data.append(data)
 

--- a/conversion_scripts/create_dataset_and_upload.py
+++ b/conversion_scripts/create_dataset_and_upload.py
@@ -6,6 +6,8 @@ import os
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--folder', type=str)
+parser.add_argument('--output_name', type=str)
+parser.add_argument('--max_samples', type=int, default=5_000_000)
 args = parser.parse_args()
 
 all_ds = DatasetDict()
@@ -24,6 +26,8 @@ for file in os.listdir(args.folder):
                 for d in data:
                     yield d
             dataset = Dataset.from_generator(genx)
+            if len(dataset) > args.max_samples:
+                dataset = dataset.shuffle(seed=42).select(range(args.max_samples))
         all_ds[file.split('.')[0]] = dataset
-import pdb; pdb.set_trace()
-all_ds.push_to_hub("allenai/preference-datasets-tulu-fixed")
+
+all_ds.push_to_hub(args.output_name)


### PR DESCRIPTION
- Fixing up preference data scripts
- automatic filtering of useless examples (= all 0 loss masks) from DPO training
- `remove_truncated_samples` on the dataset thing, allows filtering out examples that get truncated (may throw off DPO training).